### PR TITLE
Don't depend on tracing by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ tower = { version = "0.4", optional = true }
 tower-http = { version = "0.5", features = ["fs"], optional = true }
 wasm-bindgen = "=0.2.93"
 thiserror = "1"
-tracing = { version = "0.1", optional = true }
 http = "1"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ ssr = [
     "leptos/ssr",
     "leptos_meta/ssr",
     "leptos_router/ssr",
-    "dep:tracing",
 ]
 
 # Defines a size-optimized profile for the WASM bundle in release mode


### PR DESCRIPTION
After https://github.com/leptos-rs/leptos/pull/2843 tracing is optional.