### PR TITLE
Remove some warnings about unused deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,18 +10,18 @@ crate-type = ["cdylib", "rlib"]
 leptos = { version = "0.7.0"{% if nightly == "Yes" %}, features = ["nightly"]{% endif %} }
 leptos_router = { version = "0.7.0"{% if nightly == "Yes" %}, features = ["nightly"]{% endif %} }
 axum = { version = "0.7", optional = true }
-console_error_panic_hook = "0.1"
+console_error_panic_hook = { version = "0.1", optional = true}
 leptos_axum = { version = "0.7.0", optional = true }
 leptos_meta = { version = "0.7.0" }
 tokio = { version = "1", features = ["rt-multi-thread"], optional = true }
-tower = { version = "0.4", optional = true }
-tower-http = { version = "0.5", features = ["fs"], optional = true }
-wasm-bindgen = "=0.2.100"
-thiserror = "1"
-http = "1"
+wasm-bindgen = { version = "=0.2.100", optional = true }
 
 [features]
-hydrate = ["leptos/hydrate"]
+hydrate = [
+    "leptos/hydrate",
+    "dep:console_error_panic_hook",
+    "dep:wasm-bindgen",
+]
 ssr = [
     "dep:axum",
     "dep:tokio",


### PR DESCRIPTION
I wasn't able to remove *all* of them when building the server side, but at least the frontend library now doesn't have them.

ref #12 