### PR TITLE
Create rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
The file is missing in the repository. The code does not compile without it, when nightly is choosen as a feature during scaffolding.