### PR TITLE
feat: use `leptos_meta::Meta` instead of raw meta

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,5 @@
 use leptos::prelude::*;
-use leptos_meta::{provide_meta_context, MetaTags, Stylesheet, Title};
+use leptos_meta::{provide_meta_context, Meta, MetaTags, Stylesheet, Title};
 use leptos_router::{
     components::{Route, Router, Routes},
     StaticSegment,
@@ -10,8 +10,8 @@ pub fn shell(options: LeptosOptions) -> impl IntoView {
         <!DOCTYPE html>
         <html lang="en">
             <head>
-                <meta charset="utf-8"/>
-                <meta name="viewport" content="width=device-width, initial-scale=1"/>
+                <Meta charset="utf-8" />
+                <Meta name="viewport" content="width=device-width, initial-scale=1" />
                 <AutoReload options=options.clone() />
                 <HydrationScripts options/>
                 <MetaTags/>


### PR DESCRIPTION
Just a simple change I noticed while reading over the templates. As far as I can tell, `Meta` provides a little extra value over raw `meta` tags since it will be readable by `leptos_meta`.