### PR TITLE
Update to 0.8 dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,12 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-leptos = { version = "0.7.0"{% if nightly == "Yes" %}, features = ["nightly"]{% endif %} }
-leptos_router = { version = "0.7.0"{% if nightly == "Yes" %}, features = ["nightly"]{% endif %} }
-axum = { version = "0.7", optional = true }
-console_error_panic_hook = { version = "0.1", optional = true}
-leptos_axum = { version = "0.7.0", optional = true }
-leptos_meta = { version = "0.7.0" }
+leptos = { version = "0.8.0"{% if nightly == "Yes" %}, features = ["nightly"]{% endif %} }
+leptos_router = { version = "0.8.0"{% if nightly == "Yes" %}, features = ["nightly"]{% endif %} }
+axum = { version = "0.8.0", optional = true }
+console_error_panic_hook = { version = "0.1", optional = true }
+leptos_axum = { version = "0.8.0", optional = true }
+leptos_meta = { version = "0.8.0" }
 tokio = { version = "1", features = ["rt-multi-thread"], optional = true }
 wasm-bindgen = { version = "=0.2.100", optional = true }
 


### PR DESCRIPTION
This pull request updates dependencies in the `Cargo.toml` file to align with the latest versions, ensuring compatibility and access to new features.

Dependency updates:

* Updated the `leptos` dependency from version `0.7.0` to `0.8.0`.
* Updated the `leptos_router` dependency from version `0.7.0` to `0.8.0`.
* Updated the `axum` dependency from version `0.7` to `0.8.0`.
* Updated the `leptos_axum` dependency from version `0.7.0` to `0.8.0`.
* Updated the `leptos_meta` dependency from version `0.7.0` to `0.8.0`.