### PR TITLE
Remove `env` from [package.metadata.leptos] to suppress cargo-leptos warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,9 +73,6 @@ end2end-dir = "end2end"
 #  The browserlist query used for optimizing the CSS.
 browserquery = "defaults"
 
-# The environment Leptos will run in, usually either "DEV" or "PROD"
-env = "DEV"
-
 # The features to use when compiling the bin target
 #
 # Optional. Can be over-ridden with the command line parameter --bin-features


### PR DESCRIPTION
When building with the start-axum template, the following warning appears:

```
$ cargo leptos watch
    Metadata keys ["env"] from metadata.leptos are not recognized and will be ignored
...
```

The `env` key in [package.metadata.leptos] is not used by cargo-leptos, and `LEPTOS_ENV` itself
does not appear to be used by Leptos internally either, so I think it should be removed.

https://github.com/leptos-rs/leptos/discussions/2011#discussioncomment-7577148